### PR TITLE
convenient functions for solvation shell selection and counting ion pairing

### DIFF
--- a/mdgo/core.py
+++ b/mdgo/core.py
@@ -634,22 +634,9 @@ class MdRun:
             means.append(np.nanmean(distance_matrix))
         return np.mean(means)
 
-
     def get_ion_pairing(self, timestep, raw_counts=False):
         """
         This function can only be used in a universe with names.
-
-class MdJob:
-    """
-    A core class for MD results analysis.
-    """
-
-    def __init__(self, name):
-        self.name = name
-
-    @classmethod
-    def from_dict(cls):
-        return cls("name")
 
         Args:
             timestep:
@@ -669,3 +656,19 @@ class MdJob:
             return counts
         else:
             return counts_normed
+
+class MdJob:
+    """
+    A core class for MD results analysis.
+    """
+
+    def __init__(self, name):
+        self.name = name
+
+    @classmethod
+    def from_dict(cls):
+        return cls("name")
+
+    @classmethod
+    def from_recipe(cls):
+        return cls("name")

--- a/mdgo/core.py
+++ b/mdgo/core.py
@@ -23,6 +23,10 @@ from mdgo.coordination import (
 )
 from mdgo.msd import total_msd, partial_msd, special_msd
 from mdgo.residence_time import calc_neigh_corr, fit_residence_time
+from mdgo.util import resnames, mass_to_el
+from mdgo.rdf import RdfMemoizer
+from mdgo.shell_functions import get_counts, get_pair_type, count_dicts, \
+    get_radial_shell
 
 __author__ = "Tingzheng Hou"
 __version__ = "1.0"
@@ -631,6 +635,10 @@ class MdRun:
         return np.mean(means)
 
 
+    def get_ion_pairing(self, timestep, raw_counts=False):
+        """
+        This function can only be used in a universe with names.
+
 class MdJob:
     """
     A core class for MD results analysis.
@@ -643,6 +651,21 @@ class MdJob:
     def from_dict(cls):
         return cls("name")
 
-    @classmethod
-    def from_recipe(cls):
-        return cls("name")
+        Args:
+            timestep:
+            raw_counts:
+
+        Returns:
+
+        """
+        self.unwrapped_run.trajectory[timestep]
+        pairs = [get_pair_type(self.unwrapped_run, cation, self.cations, self.anions)
+                 for cation in self.cations]
+        counts = {pair_type: pairs.count(pair_type) for pair_type in pairs}
+        total_cations = len(self.cations)
+        counts_normed = {pair_type: round(count / total_cations, 3)
+                         for pair_type, count, in counts.items()}
+        if raw_counts:
+            return counts
+        else:
+            return counts_normed

--- a/mdgo/shell_functions.py
+++ b/mdgo/shell_functions.py
@@ -1,0 +1,200 @@
+# atom selection functions
+import warnings
+import numpy as np
+import MDAnalysis as mda
+from MDAnalysis.analysis import distances
+import nglview as nv
+
+# all functions
+"get_atom_group, get_n_shells, \
+    get_cation_anion_shells, get_closest_n_mol, get_radial_shell, \
+    get_counts, get_pair_type, count_dicts"
+
+
+def visualize(selection):
+    mda_view = nv.show_mdanalysis(selection)
+    mda_view.add_representation('licorice', selection='Li', color='blue')
+    return mda_view.display()
+
+
+def get_atom_group(u, selection):
+    """
+    Casts an Atom, AtomGroup, Residue, or ResidueGroup to AtomGroup.
+
+    Args:
+        u: universe that contains selection
+        selection: a selection of atoms
+
+    Returns:
+        AtomGroup
+
+    """
+    assert isinstance(selection, (mda.core.groups.Residue,
+                                  mda.core.groups.ResidueGroup,
+                                  mda.core.groups.Atom,
+                                  mda.core.groups.AtomGroup)), \
+        "central_species must be one of the preceding types"
+    if isinstance(selection, (mda.core.groups.Residue, mda.core.groups.ResidueGroup)):
+        selection = selection.atoms
+    if isinstance(selection, mda.core.groups.Atom):
+        selection = u.select_atoms(f'index {selection.index}')
+    return selection
+
+
+# test this
+def get_n_shells(u, central_species, n_shell=2, radius=3, ignore_atoms=None):
+    """
+    A list containing the nth shell at the nth index. Note that the shells have 0 intersection.
+    For example, calling get_n_shells with n_shell = 2 would return: [central_species, first_shell, second_shell].
+    This scales factorially so probably don't go over n_shell = 3
+
+    Args:
+        u: universe that contains central species
+        central_species: An Atom, AtomGroup, Residue, or ResidueGroup to AtomGroup.
+        n_shell: number of shells to return
+        radius: radius used to select atoms in next shell
+        ignore_atoms: these atoms will be ignored
+
+    Returns:
+        List of n shells
+
+    """
+    if n_shell > 3:
+        warnings.warn('get_n_shells scales factorially, very slow')
+    central_species = get_atom_group(u, central_species)
+    if not ignore_atoms:
+        ignore_atoms = u.select_atoms('')
+
+
+def get_cation_anion_shells(u, central_species, cation_group, anion_group, radius=4):
+    """
+    This is meant to help probe the solvation structure of an electrolyte solution. It will return a list of four
+    shells: [central_species (cation), first_shell (anions), second_shell (cations), third_shell (anions)].
+    Each outer shell is found by iterating through the atoms in the inner shell and searching within radius.
+
+    Args:
+        u: universe that contains central species
+        central_species: An cation that is an Atom, AtomGroup, Residue, or ResidueGroup to AtomGroup.
+        cation_group: The AtomGroup of all cations in the universe.
+        anion_group: The AtomGroup of all anions in the universe.
+        radius: the radius used to select nearby cations/anions
+
+    Returns:
+        List of four shells
+
+    """
+    central_species = get_atom_group(u, central_species)
+    first_shell = get_radial_shell(u, central_species, radius) & anion_group
+    second_shell = u.select_atoms('')
+    for res in first_shell.residues:
+        second_shell = second_shell | get_radial_shell(u, res, radius)
+    second_shell = (second_shell - central_species) & cation_group
+    third_shell = u.select_atoms('')
+    for res in second_shell:
+        third_shell = third_shell | get_radial_shell(u, res, radius)
+    third_shell = (third_shell - first_shell) & anion_group
+    fourth_shell = u.select_atoms('')
+    for res in third_shell:
+        fourth_shell = fourth_shell | get_radial_shell(u, res, radius)
+    fourth_shell = (fourth_shell - second_shell - central_species) & cation_group
+    return first_shell, second_shell, third_shell, fourth_shell
+
+
+def get_closest_n_mol(u, central_species, n_mol=5, radius=3):
+    """
+    Returns the closest n molecules to the central species, an array of their resids,
+    and an array of the distance of the closest atom in each molecule.
+
+    Args:
+        u: universe that contains central species
+        central_species: An Atom, AtomGroup, Residue, or ResidueGroup to AtomGroup.
+        n_mol: The number of molecules to return
+        radius: an initial search radius to look for closest n mol
+
+    Returns:
+        (AtomGroup[molecules], Array[resids], Array[distances])
+
+    """
+    central_species = get_atom_group(u, central_species)
+    coords = central_species.center_of_mass()
+    str_coords = " ".join(str(coord) for coord in coords)
+    partial_shell = u.select_atoms(f'point {str_coords} {radius}')
+    shell_resids = partial_shell.resids
+    if len(np.unique(shell_resids)) < n_mol + 1:
+        return get_closest_n_mol(u, central_species, n_mol, radius + 1)
+    radii = distances.distance_array(coords, partial_shell.positions, box=u.dimensions)[0]
+    ordering = np.argsort(radii)
+    ordered_resids = shell_resids[ordering]
+    closest_n_resix = np.sort(np.unique(ordered_resids, return_index=True)[1])[0:n_mol + 1]
+    str_resids = " ".join(str(resid) for resid in ordered_resids[closest_n_resix])
+    full_shell = u.select_atoms(f'resid {str_resids}')
+    return full_shell, ordered_resids[closest_n_resix], radii[ordering][closest_n_resix]
+
+
+def get_radial_shell(u, central_species, radius):
+    """
+    Returns all molecules with atoms within the radius of the central species. (specifically, within the radius
+    of the COM of central species).
+
+    Args:
+        u: universe that contains central species
+        central_species: An Atom, AtomGroup, Residue, or ResidueGroup to AtomGroup.
+        radius: radius used for atom selection
+
+    Returns:
+        An AtomGroup
+
+    """
+    central_species = get_atom_group(u, central_species)
+    coords = central_species.center_of_mass()
+    str_coords = " ".join(str(coord) for coord in coords)
+    partial_shell = u.select_atoms(f'point {str_coords} {radius}')
+    full_shell = partial_shell.residues.atoms
+    return full_shell
+
+
+# atom group counters
+
+def get_counts(atom_group):
+    unique_ids = np.unique(atom_group.resids, return_index=True)
+    names, counts = np.unique(atom_group.resnames[unique_ids[1]], return_counts=True)
+    return {i: j for i, j in zip(names, counts)}
+
+
+def get_pair_type(u, central_species, cation_group, anion_group, radius=4):
+    cation_name = cation_group.names[0]
+    anion_name = anion_group.names[0]
+    first, second, third, fourth = (get_counts(shell) for shell in
+                                    get_cation_anion_shells(u, central_species, cation_group,
+                                                            anion_group, radius))
+    if len(first) == 0:
+        return "SSIP"
+    if (len(first) == 1) & (len(second) == 0):
+        return "CIP"
+    else:
+        return "AGG"
+
+
+def count_dicts(dict_list):
+    unique_dicts = []
+    dict_counts = []
+    j = 0
+    new_dics = 0
+    for dic in dict_list:
+        j += 1
+        new = True
+        for i, unique_dict in enumerate(unique_dicts):
+            if unique_dict == dic:
+                dict_counts[i] += 1
+                new = False
+        if new:
+            new_dics += 1
+            unique_dicts.append(dic)
+            dict_counts.append(1)
+    print('unique:', len(unique_dicts))
+    print('length: ', len(dict_counts))
+    print('sum: ', sum(dict_counts))
+    print('j', j)
+    print('new dics: ', new_dics)
+    #for i in rang
+    return {count: dic for count, dic in zip(dict_counts, unique_dicts)}

--- a/tests/test_shell_functions.py
+++ b/tests/test_shell_functions.py
@@ -1,0 +1,8 @@
+import unittest
+
+
+class ShellFunctionTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        None


### PR DESCRIPTION
This commit duplicates a lot of functionality in other branches. I think this implementation may be a bit more elegant. We should identify duplicate usage and refactor that code. The refactoring should probably be split into a separate pull request.

Eventually, this code will be incorporated into MDAnalysis, relying on MDanalysis for the backend but using an identical signature for get_ion_pairing. That can be changed down the road.

Needs unit testing!